### PR TITLE
min_samples_split must be >=2 for integer values (#136)

### DIFF
--- a/hpsklearn/components.py
+++ b/hpsklearn/components.py
@@ -1021,7 +1021,7 @@ def decision_tree(name,
         max_depth=max_depth,
         min_samples_split=scope.int(hp.quniform(
             _name('min_samples_split'),
-            1, 10, 1)) if min_samples_split is None else min_samples_split,
+            2, 10, 1)) if min_samples_split is None else min_samples_split,
         min_samples_leaf=scope.int(hp.quniform(
             _name('min_samples_leaf'),
             1, 5, 1)) if min_samples_leaf is None else min_samples_leaf,


### PR DESCRIPTION
Otherwise, the following error is raised:

ValueError: min_samples_split must be an integer greater than 1 or a float in (0.0, 1.0]; got the integer 1